### PR TITLE
Fix typo in TimingPoints parser (?)

### DIFF
--- a/OppaiSharp/Parser.cs
+++ b/OppaiSharp/Parser.cs
@@ -96,7 +96,7 @@ namespace OppaiSharp
 
                             if (splitted.Length > 8)
                                 Warn("timing point with trailing values");
-                            else if (splitted.Length < 7) {
+                            else if (splitted.Length < 2) {
                                 Warn("timing point with too little values");
                                 continue;
                             }


### PR DESCRIPTION
timing points with 2 elements exist, and they do work.
eg. https://osu.ppy.sh/b/256

This mainly fixes calls to GetMaxCombo on maps with these short timing points

All included Unit tests still pass.